### PR TITLE
add flush cdn cmd

### DIFF
--- a/scripts/update_tasks
+++ b/scripts/update_tasks
@@ -6,3 +6,5 @@ cd app/themes/shifter
 /usr/local/bin/npm rebuild > /tmp/npm_rebuild.log
 /usr/bin/gulp --production > /tmp/gulp.log
 chown -R nginx:nginx /var/www/vhosts/getshifter.io
+cd /var/www/vhosts/getshifter.io
+/usr/local/bin/wp c3 flush all --allow-root > /tmp/flush_cdn.log


### PR DESCRIPTION
getshifter.io should remove CDN cache when deploy finished.