### PR TITLE
Remove duplicated Blog post type

### DIFF
--- a/app/themes/shifter/lib/misc/extend-post-types.php
+++ b/app/themes/shifter/lib/misc/extend-post-types.php
@@ -43,7 +43,7 @@ function label_factory( $name, $singular = false, $plural = false ) {
 // Posts "Blog"
 function post_cpt() {
 
-  $labels = label_factory('Blog', 'Post', 'Blog');
+  $labels = label_factory('Blog', 'Post');
 
   $args = array(
     'label'                 => $labels['name'],


### PR DESCRIPTION
`'Blog'` post type is duplicated.